### PR TITLE
task용 iam role 생성 및 적용

### DIFF
--- a/.idea/ecs.tf
+++ b/.idea/ecs.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "gateway_task" {
   cpu                      = "256"
   memory                   = "512"
   execution_role_arn       = aws_iam_role.execution_role.arn
-  task_role_arn            = aws_iam_role.execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
 
   container_definitions = jsonencode([
     {
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "msa_task" {
   cpu                     = "256"
   memory                  = "512"
   execution_role_arn      = aws_iam_role.execution_role.arn
-  task_role_arn           = aws_iam_role.execution_role.arn
+  task_role_arn           = aws_iam_role.task_role.arn
 
   container_definitions = jsonencode([
     {
@@ -201,7 +201,7 @@ resource "aws_ecs_task_definition" "redis_task" {
   cpu                      = "256"
   memory                   = "512"
   execution_role_arn       = aws_iam_role.execution_role.arn
-  task_role_arn            = aws_iam_role.execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
 
   container_definitions = jsonencode([
     {

--- a/.idea/ecs.tf
+++ b/.idea/ecs.tf
@@ -269,4 +269,3 @@ resource "aws_appautoscaling_policy" "msa_cpu_scaling_policy" {
     scale_out_cooldown = 60
   }
 }
-

--- a/.idea/iam.tf
+++ b/.idea/iam.tf
@@ -1,13 +1,56 @@
-# IAM ROLE 생성
+# -------------------------
+# 공통 Assume Role Policy
+# -------------------------
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# -------------------------
+# ECS Execution Role (for ECS 시스템용)
+# -------------------------
 resource "aws_iam_role" "execution_role" {
   name               = "${var.APP_NAME}-${var.Environment}-ecs-execution-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 
   tags = {
-    Name        = "${var.APP_NAME}-ecs-role"
+    Name        = "${var.APP_NAME}-ecs-execution-role"
     Environment = var.Environment
   }
 }
+
+# Execution Role에 AmazonECSTaskExecutionRolePolicy 붙이기 (필수)
+resource "aws_iam_role_policy_attachment" "ecs_execution_policy" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# -------------------------
+# ECS Task Role (for App 컨테이너용)
+# -------------------------
+resource "aws_iam_role" "task_role" {
+  name               = "${var.APP_NAME}-${var.Environment}-ecs-task-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+
+  tags = {
+    Name        = "${var.APP_NAME}-ecs-task-role"
+    Environment = var.Environment
+  }
+}
+
+# -------------------------
+# 정책들 생성
+# -------------------------
 
 # SQS 전송 권한
 resource "aws_iam_policy" "sqs_access" {
@@ -18,17 +61,17 @@ resource "aws_iam_policy" "sqs_access" {
     Statement = [{
       Effect   = "Allow",
       Action   = [
-        "sqs:SendMessage",        # 메시지 전송 (모든 서버 필요)
-        "sqs:ReceiveMessage",     # 메시지 수신
-        "sqs:DeleteMessage",      # 수신 후 삭제
-        "sqs:GetQueueAttributes"  # 큐 속성 조회 (수신 쪽에서 주로 필요)
+        "sqs:SendMessage",
+        "sqs:ReceiveMessage",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes"
       ],
-      Resource = "*"  # 또는 특정 SQS ARN으로 제한 가능
+      Resource = "*"
     }]
   })
 }
 
-# RDS 권한 (보통 연결만 하므로 EC2 권한으로 처리)
+# RDS 권한
 resource "aws_iam_policy" "rds_access" {
   name = "${var.APP_NAME}-${var.Environment}-rds-access"
 
@@ -62,69 +105,66 @@ resource "aws_iam_policy" "redis_access" {
   })
 }
 
-# S3 사용자 프로필 버킷 접근 권한
+# S3 접근 권한
 resource "aws_iam_policy" "s3_user_profile_access" {
   name = "${var.APP_NAME}-${var.Environment}-s3-access"
 
   policy = jsonencode({
     Version = "2012-10-17",
-    Statement = [
-      {
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject"
-        ],
-        Resource = "arn:aws:s3:::couponmoa-user-profile-prod/*"
-      }
-    ]
+    Statement = [{
+      Effect = "Allow",
+      Action = [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      Resource = "arn:aws:s3:::couponmoa-user-profile-prod/*"
+    }]
   })
 }
 
-# IAM ROLE에 SQS 정책 추가
-resource "aws_iam_role_policy_attachment" "attach_sqs_policy" {
+# -------------------------
+# 정책 Attach (Task Role & Execution Role 둘 다)
+# -------------------------
+
+# --- Task Role Attach ---
+resource "aws_iam_role_policy_attachment" "task_role_attach_sqs" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = aws_iam_policy.sqs_access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_attach_rds" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = aws_iam_policy.rds_access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_attach_redis" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = aws_iam_policy.redis_access.arn
+}
+
+resource "aws_iam_role_policy_attachment" "task_role_attach_s3" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = aws_iam_policy.s3_user_profile_access.arn
+}
+
+# --- Execution Role Attach ---
+resource "aws_iam_role_policy_attachment" "execution_role_attach_sqs" {
   role       = aws_iam_role.execution_role.name
   policy_arn = aws_iam_policy.sqs_access.arn
 }
 
-# IAM ROLE에 RDS 정책 추가
-resource "aws_iam_role_policy_attachment" "attach_rds_policy" {
+resource "aws_iam_role_policy_attachment" "execution_role_attach_rds" {
   role       = aws_iam_role.execution_role.name
   policy_arn = aws_iam_policy.rds_access.arn
 }
 
-# IAM ROLE에 Redis 정책(ElasticCache) 추가
-resource "aws_iam_role_policy_attachment" "attach_redis_policy" {
+resource "aws_iam_role_policy_attachment" "execution_role_attach_redis" {
   role       = aws_iam_role.execution_role.name
   policy_arn = aws_iam_policy.redis_access.arn
 }
 
-# IAM ROLE에 S3 접근 권한 정책 추가
-resource "aws_iam_role_policy_attachment" "attach_s3_policy" {
+resource "aws_iam_role_policy_attachment" "execution_role_attach_s3" {
   role       = aws_iam_role.execution_role.name
   policy_arn = aws_iam_policy.s3_user_profile_access.arn
-}
-
-# IAM Role 권한 허가
-# ECS Task가 IAM ROLE을 사용하도록 허용
-data "aws_iam_policy_document" "assume_role_policy" {
-  statement {
-    effect = "Allow"
-
-    actions = [
-      "sts:AssumeRole"
-    ]
-
-    principals {
-      type        = "Service"
-      identifiers = ["ecs-tasks.amazonaws.com"]
-    }
-  }
-}
-
-# ECS Task AWS 자원 접근 허가
-resource "aws_iam_role_policy_attachment" "ecs_execution_policy" {
-  role       = aws_iam_role.execution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }


### PR DESCRIPTION
# 기존 문제
- SQS가 실제로 동작하지 않는 문제
  ```
    #ecs.tf
    ...
    execution_role_arn       = aws_iam_role.execution_role.arn
    task_role_arn            = aws_iam_role.execution_role.arn
  ```
  - execution_role을 task_role_arn과 task_role_arn 이 같이 사용하여 문제가 생긴듯 함

# 변경점
- executionRoleArn 외에 taskRoleArn iam role 추가
- 코드 변경점
  ```
    #ecs.tf
    ...
    execution_role_arn       = aws_iam_role.execution_role.arn
    task_role_arn            = aws_iam_role.task_role.arn
  ```
  - task_role_arn에 적용할 task iam role을 만들고, 각각 따로 iam role을 사용하게 만들어서 꼬임 문제 방지